### PR TITLE
add block comments, allowing /' ... '/

### DIFF
--- a/grammars/plantuml.json
+++ b/grammars/plantuml.json
@@ -11,6 +11,16 @@
          "begin":"^(#|')",
          "name":"comment.line.plantuml"
       },
+      {
+            "name": "comment.block.plantuml",
+            "begin": "/'",
+            "end": "'/",
+            "beginCaptures": {
+                "0": {
+                    "name": "comment.line.plantuml"
+                }
+            }
+      },
 
       {
          "match":"\\b(abstract|actor|class|component|enum|interface|object|participant|state|usecase)\\b",


### PR DESCRIPTION
try :

@startuml
Bob -> Alice : hello
/'   in a block comment here:

They could say:
hallo
hello
hi
Bonjour
你好
aloha
'/
@enduml

maybe 'captures' is useless. :-)
