### PR TITLE
Fix grammar scopeName

### DIFF
--- a/grammars/plantuml.json
+++ b/grammars/plantuml.json
@@ -67,7 +67,5 @@
          "match":"\\b[a-z_]+[A-Za-z_0-9]*\\b",
          "name":"variable.parameter.plantuml"
       }
-   ],
-   "name":"PlantUML",
-   "scopeName":"plantuml"
+   ]
 }


### PR DESCRIPTION
The plantuml.json grammar file contains the keys for name and scopeName twice. The pair appear once in the top and once in the bottom:

"scopeName": "source.plantuml",
"name": "PlantUML",
...
"name":"PlantUML",
"scopeName":"plantuml"

The scopeName that is used now it the last one, "plantuml", but it should be "source.plantuml". So I removed the last pair of name and scopeName.
