### PR TITLE
Adding highlights for "cloud" and "database" keywords

### DIFF
--- a/grammars/plantuml.json
+++ b/grammars/plantuml.json
@@ -36,7 +36,7 @@
           }
       },
       {
-         "match":"\\b(@enduml|@startuml|activate|again|also|alt|as|autonumber|bottom|box|break|center|create|critical|deactivate|destroy|down|else|end|endif|endwhile|footbox|footer|fork|group|header|hide|if|is|left|link|loop|namespace|newpage|note|of|on|opt|over|package|page|par|partition|ref|repeat|return|right|rotate|show|skin|skinparam|start|stop|title|top|top to bottom direction|up|while)\\b",
+         "match":"\\b(@enduml|@startuml|activate|again|also|alt|as|autonumber|bottom|box|break|center|cloud|create|critical|database|deactivate|destroy|down|else|end|endif|endwhile|footbox|footer|fork|group|header|hide|if|is|left|link|loop|namespace|newpage|note|of|on|opt|over|package|page|par|partition|ref|repeat|return|right|rotate|show|skin|skinparam|start|stop|title|top|top to bottom direction|up|while)\\b",
          "name":"keyword.control.plantuml"
       },
       {


### PR DESCRIPTION
The "cloud" and "database" keywords are used in a component diagram creation.

http://plantuml.com/en/guide